### PR TITLE
Implement CRUD Endpoints for Products

### DIFF
--- a/Backend/Controllers/ProductsController.cs
+++ b/Backend/Controllers/ProductsController.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Identity.Web.Resource;
 using VicShopAPI.Models;
 using VicShopAPI.Repositories;
 
@@ -28,5 +30,34 @@ public class ProductsController : ControllerBase
         var product = await _repository.GetBySlugAsync(slug);
         if (product == null) return NotFound();
         return Ok(product);
+    }
+
+    [Authorize]
+    [RequiredScope("products.admin")]
+    [HttpPost]
+    public async Task<ActionResult<Product>> Create(Product product)
+    {
+        await _repository.CreateAsync(product);
+        return CreatedAtAction(nameof(GetBySlug), new { slug = product.Slug }, product);
+    }
+
+    [Authorize]
+    [RequiredScope("products.admin")]
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(string id, Product product)
+    {
+        if (id != product.Id) return BadRequest();
+        
+        await _repository.UpdateAsync(id, product);
+        return NoContent();
+    }
+
+    [Authorize]
+    [RequiredScope("products.admin")]
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(string id)
+    {
+        await _repository.DeleteAsync(id);
+        return NoContent();
     }
 }

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -42,7 +42,7 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowFrontend", policy =>
     {
-        policy.WithOrigins(builder.Configuration["FrontendUrl"] ?? "http://localhost:5173")
+        policy.WithOrigins(builder.Configuration["FrontendUrl"] ?? "http://localhost:5173", "http://localhost:5174")
             .AllowAnyHeader()
             .AllowAnyMethod()
             .AllowCredentials();

--- a/Backend/Repositories/IProductRepository.cs
+++ b/Backend/Repositories/IProductRepository.cs
@@ -6,4 +6,7 @@ public interface IProductRepository
 {
     Task<List<Product>> GetAllAsync(string? team = null, string? league = null);
     Task<Product?> GetBySlugAsync(string slug);
+    Task CreateAsync(Product product);
+    Task UpdateAsync(string id, Product product);
+    Task DeleteAsync(string id);
 }

--- a/Backend/Repositories/ProductRepository.cs
+++ b/Backend/Repositories/ProductRepository.cs
@@ -29,4 +29,19 @@ public class ProductRepository : IProductRepository
 
     public async Task<Product?> GetBySlugAsync(string slug) =>
         await _products.Find(p => p.Slug == slug).FirstOrDefaultAsync();
+
+    public async Task CreateAsync(Product product)
+    {
+        await _products.InsertOneAsync(product);
+    }
+
+    public async Task UpdateAsync(string id, Product product)
+    {
+        await _products.ReplaceOneAsync(p => p.Id == id, product);
+    }
+
+    public async Task DeleteAsync(string id)
+    {
+        await _products.DeleteOneAsync(p => p.Id == id);
+    }
 }

--- a/Backend/VicShopAPI.Tests/Controllers/ProductsControllerTests.cs
+++ b/Backend/VicShopAPI.Tests/Controllers/ProductsControllerTests.cs
@@ -68,4 +68,83 @@ public class ProductsControllerTests
         // Assert
         Assert.IsType<NotFoundResult>(result.Result);
     }
+    [Fact]
+    public async Task Create_ReturnsCreatedAtAction()
+    {
+        // Arrange
+        var product = new Product { Id = "1", Title = "New Product", Slug = "new-product" };
+        _mockRepo.Setup(repo => repo.CreateAsync(product)).Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _controller.Create(product);
+
+        // Assert
+        var createdAtActionResult = Assert.IsType<CreatedAtActionResult>(result.Result);
+        Assert.Equal("GetBySlug", createdAtActionResult.ActionName);
+        Assert.Equal(product.Slug, createdAtActionResult.RouteValues["slug"]);
+        Assert.Equal(product, createdAtActionResult.Value);
+    }
+
+    [Fact]
+    public async Task Update_ReturnsNoContent_WhenIdMatches()
+    {
+        // Arrange
+        var id = "1";
+        var product = new Product { Id = id, Title = "Updated Product" };
+        _mockRepo.Setup(repo => repo.UpdateAsync(id, product)).Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _controller.Update(id, product);
+
+        // Assert
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task Update_ReturnsBadRequest_WhenIdMismatch()
+    {
+        // Arrange
+        var id = "1";
+        var product = new Product { Id = "2", Title = "Updated Product" };
+
+        // Act
+        var result = await _controller.Update(id, product);
+
+        // Assert
+        Assert.IsType<BadRequestResult>(result);
+    }
+
+    [Fact]
+    public async Task Delete_ReturnsNoContent()
+    {
+        // Arrange
+        var id = "1";
+        _mockRepo.Setup(repo => repo.DeleteAsync(id)).Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _controller.Delete(id);
+
+        // Assert
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Theory]
+    [InlineData(nameof(ProductsController.Create))]
+    [InlineData(nameof(ProductsController.Update))]
+    [InlineData(nameof(ProductsController.Delete))]
+    public void Endpoints_Have_Authorize_And_RequiredScope_Attributes(string methodName)
+    {
+        // Arrange
+        var method = typeof(ProductsController).GetMethod(methodName);
+
+        // Act
+        var authorizeAttribute = method.GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute), false).FirstOrDefault();
+        var requiredScopeAttribute = method.GetCustomAttributes(typeof(Microsoft.Identity.Web.Resource.RequiredScopeAttribute), false).FirstOrDefault() as Microsoft.Identity.Web.Resource.RequiredScopeAttribute;
+
+        // Assert
+        Assert.NotNull(authorizeAttribute);
+        Assert.NotNull(requiredScopeAttribute);
+        var scopes = requiredScopeAttribute.AcceptedScope;
+        Assert.Contains("products.admin", scopes);
+    }
 }


### PR DESCRIPTION
Closes #8. Adds protected Create, Update, and Delete endpoints to ProductsController with unit tests and scope validation.